### PR TITLE
Add iteration over functions to cobweb_plt

### DIFF
--- a/pynamical/pynamical.py
+++ b/pynamical/pynamical.py
@@ -1044,7 +1044,7 @@ def phase_diagram_3d(
     )
 
 
-def get_cobweb_points(model, r, x, n):
+def get_cobweb_points(model, r, x, n, iters):
     """
     Calculate the vertices of cobweb lines for a cobweb plot.
 
@@ -1076,17 +1076,30 @@ def get_cobweb_points(model, r, x, n):
         cobweb_x_vals, cobweb_y_vals
     """
     cobweb_points = [(x, 0)]
-    for _ in range(n):
-        y1 = model(x, r)
-        cobweb_points.append((x, y1))
-        cobweb_points.append((y1, y1))
-        y2 = model(y1, r)
-        cobweb_points.append((y1, y2))
-        x = y1
+    if iters == 1:
+        for _ in range(n):
+            y1 = model(x, r)
+            cobweb_points.append((x, y1))
+            cobweb_points.append((y1, y1))
+            y2 = model(y1, r)
+            cobweb_points.append((y1, y2))
+            x = y1
+    else:
+        for _ in range(n):
+            y1 = model(x, r)
+            for i in range(iters-1):
+                y1 = model(y1, r)
+            cobweb_points.append((x, y1))
+            cobweb_points.append((y1, y1))
+            y2 = model(y1, r)
+            for i in range(iters-1):
+                y2 = model(y2, r)
+            cobweb_points.append((y1, y2))
+            x = y1
     return zip(*cobweb_points)
 
 
-def get_function_points(model, r, n, start, end):
+def get_function_points(model, r, point_n, start, end, n):
     """
     Calculate model results for n population values.
 
@@ -1110,15 +1123,19 @@ def get_function_points(model, r, n, start, end):
     tuple
         x_vals, y_vals
     """
-    x_vals = np.linspace(start, end, n)
+    x_vals = np.linspace(start, end, point_n)
     y_vals = [model(x, r) for x in x_vals]
+    if n > 1:
+        for i in range(n-1):
+            y_vals = [model(x, r) for x in y_vals]
     return x_vals, y_vals
 
 
 def cobweb_plot(
-    model=logistic_map,
+    model=func,
     r=0,
-    function_n=1000,
+    function_n=1,
+    function_point_n=1000,
     cobweb_n=100,
     cobweb_x=0.5,
     num_discard=0,
@@ -1204,9 +1221,9 @@ def cobweb_plot(
         label_font = get_label_font()
 
     func_x_vals, func_y_vals = get_function_points(
-        model=model, r=r, n=function_n, start=start, end=end
+        model=model, r=r, point_n=function_point_n, start=start, end=end, n=function_n
     )
-    cobweb_x_vals, cobweb_y_vals = get_cobweb_points(model=model, r=r, x=cobweb_x, n=cobweb_n)
+    cobweb_x_vals, cobweb_y_vals = get_cobweb_points(model=model, r=r, x=cobweb_x, n=cobweb_n, iters=function_n)
     cobweb_x_vals = cobweb_x_vals[num_discard:]
     cobweb_y_vals = cobweb_y_vals[num_discard:]
 

--- a/pynamical/pynamical.py
+++ b/pynamical/pynamical.py
@@ -1132,7 +1132,7 @@ def get_function_points(model, r, point_n, start, end, n):
 
 
 def cobweb_plot(
-    model=func,
+    model=logistic_map,
     r=0,
     function_n=1,
     function_point_n=1000,


### PR DESCRIPTION
The cobweb_plt function has a comment
```    
"""
...
function_n: int
        number of iterations of the function to run
...
"""
```
It made me think that it ought to apply successive iterations of the map. 
I added that functionality.

Example code:
```
def func_0 (x,r):
    return (2*x)%1

def func_1 (x,r):
    if hasattr(x, 'len'):
        y = np.zeros(x.shape)
        for i in range(len(x)):
            if x[i] <= 1/3:
                y[i] = 3*x[i]
            else :
                y[i] = 3/2*(1-x[i])
    else:
        if x <= 1/3:
            y = 3*x
        else :
             y = 3/2*(1-x)
    return y

cobweb_plot(model=func_0, function_n=2, cobweb_n=20, cobweb_x=3/5+0.001, function_point_n=10000)
cobweb_plot(model=func_1, function_n=3, cobweb_n=20, cobweb_x=3/5+0.001, function_point_n=10000)
```
<img width="536" height="538" alt="cobwep_plt_1" src="https://github.com/user-attachments/assets/a4760c43-d329-41f4-bfc1-7cb6a3ff266c" />
<img width="536" height="538" alt="cobwep_plt_2" src="https://github.com/user-attachments/assets/d4bcbd92-8043-457f-af29-295bf6499bae" />
